### PR TITLE
Make wuwei ready for ASDF 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Easiest using QuickLisp:
 4. Load everything:
 
      (ql:quickload "wuwei")
-     (ql:quickload "wuwei-examples")  ; if wanted
+     (ql:quickload "wuwei/examples")  ; if wanted
 
 5. Start the server
 

--- a/heroku-setup.lisp
+++ b/heroku-setup.lisp
@@ -3,12 +3,12 @@
 (print ">>> Building system....")
 
 ;(asdf:clear-system "wuwei")
-;(asdf:clear-system "wuwei-examples")
+;(asdf:clear-system "wuwei/examples")
 
 (load (make-pathname :directory *build-dir* :defaults "wuwei.asd"))
 ;;; This is NOT WORKING, and the build gets Wuwei from Quicklisp.  But that's better than what it was doing before, which was using a completely obsolete version...no fucking idea what is going on here.
 (push (make-pathname :directory *build-dir*) asdf:*central-registry*)
 
-(ql:quickload :wuwei-examples)
+(ql:quickload :wuwei/examples)
 
 (print ">>> Done building system")

--- a/src/heroku.lisp
+++ b/src/heroku.lisp
@@ -7,13 +7,11 @@
 ;;; Called from an application's heroku-setup.lisp
 ;;; Directory is a relative path from the app root.
 (defun heroku-install-wupub-files (&optional (directory '("wupub")))
-  (asdf:run-shell-command
-   (format nil "cp -r ~Apublic ~A"
-	   (namestring (asdf:component-pathname (asdf:find-system :wuwei)))
-	   (namestring (make-pathname :directory (append cl-user::*build-dir* directory))) 
-	   )))
+  (uiop:run-program
+   `("cp" "-r" ,(uiop:native-namestring (asdf:system-relative-pathname "wuwei" "public"))
+          ,(uiop:native-namestring (uiop:subpathname cl-user::*build-dir* directory)))))
 
 ;;; Called from cl-user::initialize-application, which is called at startup
 (defun wuwei-initialize-application (&key (directory "./wupub/"))
   (locate-public-directory directory)
-  (setf *developer-mode* (equal (ccl:getenv "DEVELOPER_MODE") "Y")))  
+  (setf *developer-mode* (equal (uiop:getenv "DEVELOPER_MODE") "Y")))

--- a/wuwei.asd
+++ b/wuwei.asd
@@ -1,9 +1,7 @@
-(in-package :asdf)
-
 #+ALLEGRO
 (require :aserve)
 
-(defsystem :wuwei
+(defsystem "wuwei"
   :name "WuWei"
   :description "Tools for developing Ajaxy web applications"
   :long-description "WuWei is a toolkit for building Ajax web pages and web sites in Common Lisp. It's designed to be light-weight, a toolkit rather than a platform. Features include: Continuation-based AJAX user interfaces; Server-side DOM operations (add/remove elements, visual fades, drag and drop); High-level interfaces to in-place-editing and autocomplete widgets; Login and session management"
@@ -11,18 +9,18 @@
   :author "Mike Travers <mt@hyperphor.com>"
   :license "MIT"
   :serial t
-  :depends-on (#-ALLEGRO :aserve :cl-json :mtlisp #-ALLEGRO :ironclad 
-			 :drakma)	;for oauth2
-  :components 
+  :depends-on (#-ALLEGRO "aserve" "cl-json" "mtlisp" #-ALLEGRO "ironclad"
+			 "drakma")	;for oauth2
+  :components
   ((:static-file "wuwei.asd")
    (:module :src
-	    :serial t      
+	    :serial t
 	    :components
 	    ((:file "package")
 
 	     (:file "htmlgen-patch")
 	     (:file "cl-json-patches")
-     
+
 	     (:file "config")
 	     (:file "net-utils")
 	     (:file "web")
@@ -42,15 +40,15 @@
 	     #+:CCL (:file "heroku")
 	     ))))
 
-(defsystem :wuwei-examples
+(defsystem "wuwei/examples"
     :name "WuWei Examples"
     :description "Example for WuWei"
     :version "0.1"
     :author "Mike Travers <mt@hyperphor.com>"
     :license "MIT"
     :serial t
-    :depends-on (:wuwei :drakma)
-    :components 
+    :depends-on ("wuwei" "drakma")
+    :components
     ((:module "examples"
 	     :serial t
 	     :components
@@ -63,5 +61,3 @@
 	      (:file "arc-challenge")
 	      (:file "go")		;set up for Heroku
 	      ))))
-
-


### PR DESCRIPTION
1- Follow the ASDF best_practices document for wuwei.asd, notably
  use wuwei/examples instead of wuwei-examples as secondary system name.

2- Stop using the deprecated run-shell-command, use shell-program.