### PR TITLE
replace run-shell-command

### DIFF
--- a/src/heroku.lisp
+++ b/src/heroku.lisp
@@ -7,7 +7,7 @@
 ;;; Called from an application's heroku-setup.lisp
 ;;; Directory is a relative path from the app root.
 (defun heroku-install-wupub-files (&optional (directory '("wupub")))
-  (asdf:run-shell-command
+  (uiop:run-program
    (format nil "cp -r ~Apublic ~A"
 	   (namestring (asdf:component-pathname (asdf:find-system :wuwei)))
 	   (namestring (make-pathname :directory (append cl-user::*build-dir* directory))) 

--- a/src/net-utils.lisp
+++ b/src/net-utils.lisp
@@ -13,7 +13,7 @@
 	(url (if query
 		 (string+ url "?" (query-to-form-urlencoded query))
 		 url)))
-    (unless (zerop (asdf:run-shell-command "wget -c \"~A\" -O ~A" url (pathname temp-file)))
+    (unless (zerop (uiop:run-program (format nil "wget -c \"~A\" -O ~A" url (pathname temp-file))))
       (error "Shell command failed"))
     (file-to-string temp-file)))
 


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```